### PR TITLE
Performance improvements

### DIFF
--- a/fastest-csv.gemspec
+++ b/fastest-csv.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake-compiler', '~> 0.9'
   gem.add_development_dependency 'minitest', '~> 5.4'
   gem.add_development_dependency 'yard', '~> 0.8.7'
+  gem.add_development_dependency 'ruby-prof'
 
 end

--- a/lib/fastest-csv/version.rb
+++ b/lib/fastest-csv/version.rb
@@ -1,3 +1,3 @@
 class FastestCSV
-  VERSION = "0.7.5"
+  VERSION = "0.7.6"
 end


### PR DESCRIPTION
Looked like there were some quick wins (almost a 50% improvement!) to be had by removing hash lookups and inlining the call to CsvParser.parse_line.

I used this profiling script on a ~10 million row file with 3 columns (customer_custom_segments):

```
require 'fastest_csv'
require 'ruby-prof'

result = RubyProf.profile do
  FastestCSV.foreach("..."){ |line| }
end

printer = RubyProf::FlatPrinter.new(result)
printer.print(STDOUT)
```

Before:

```
Measure Mode: wall_time
Thread ID: 70180244161020
Fiber ID: 70180244357580
Total: 49.899197
Sort by: self_time

 %self      total      self      wait     child     calls  name
 35.11     46.832    17.520     0.000    29.311  9954918   FastestCSV#shift 
 20.65     10.303    10.303     0.000     0.000  9954917   <Module::CsvParser>#parse_line 
 12.59      6.283     6.283     0.000     0.000  9954918   IO#gets 
 11.51      5.744     5.744     0.000     0.000 19909834   FastestCSV#check_field_count 
 10.52     15.553     5.250     0.000    10.303  9954917   <Class::FastestCSV>#parse_line_no_check 
  6.15     49.899     3.067     0.000    46.832        1   FastestCSV#each 
  3.47      1.732     1.732     0.000     0.000  9954918   Kernel#class 
  0.00      0.000     0.000     0.000     0.000        1   Hash#merge 
  0.00      0.000     0.000     0.000     0.000        1   File#initialize 
  0.00     49.899     0.000     0.000    49.899        1   Global#[No method] 
  0.00      0.000     0.000     0.000     0.000        1   FastestCSV#initialize 
  0.00      0.000     0.000     0.000     0.000        1   IO#close 
  0.00      0.000     0.000     0.000     0.000        1   <Class::FastestCSV>#assert_valid_grammar 
  0.00     49.899     0.000     0.000    49.899        1   <Class::FastestCSV>#open 
  0.00      0.000     0.000     0.000     0.000        1   FastestCSV#close 
  0.00      0.000     0.000     0.000     0.000        1   Hash#initialize_copy 
  0.00     49.899     0.000     0.000    49.899        1   <Class::FastestCSV>#foreach 
  0.00      0.000     0.000     0.000     0.000        1   Class#new 
  0.00      0.000     0.000     0.000     0.000        2   Array#include? 
  0.00      0.000     0.000     0.000     0.000        1   Kernel#block_given? 
  0.00      0.000     0.000     0.000     0.000        1   <Class::IO>#open 
  0.00      0.000     0.000     0.000     0.000        2   Kernel#is_a? 
  0.00      0.000     0.000     0.000     0.000        1   Kernel#initialize_dup 
  0.00      0.000     0.000     0.000     0.000        1   Kernel#nil? 
```

After:

```
Measure Mode: wall_time
Thread ID: 70297688867320
Fiber ID: 70297689033300
Total: 30.377727
Sort by: self_time

 %self      total      self      wait     child     calls  name
 37.89     26.924    11.511     0.000    15.412  9954918   FastestCSV#shift 
 30.59      9.294     9.294     0.000     0.000  9954917   <Module::CsvParser>#parse_line 
 20.14      6.119     6.119     0.000     0.000  9954918   IO#gets 
 11.37     30.378     3.454     0.000    26.924        1   FastestCSV#each 
  0.00      0.000     0.000     0.000     0.000        1   File#initialize 
  0.00     30.378     0.000     0.000    30.378        1   Global#[No method] 
  0.00      0.000     0.000     0.000     0.000        1   IO#close 
  0.00      0.000     0.000     0.000     0.000        1   FastestCSV#initialize 
  0.00      0.000     0.000     0.000     0.000        1   <Class::FastestCSV>#assert_valid_grammar 
  0.00     30.378     0.000     0.000    30.378        1   <Class::FastestCSV>#open 
  0.00      0.000     0.000     0.000     0.000        1   Hash#initialize_copy 
  0.00      0.000     0.000     0.000     0.000        1   FastestCSV#close 
  0.00     30.378     0.000     0.000    30.378        1   <Class::FastestCSV>#foreach 
  0.00      0.000     0.000     0.000     0.000        1   Hash#merge 
  0.00      0.000     0.000     0.000     0.000        1   Class#new 
  0.00      0.000     0.000     0.000     0.000        1   Kernel#initialize_dup 
  0.00      0.000     0.000     0.000     0.000        1   Kernel#block_given? 
  0.00      0.000     0.000     0.000     0.000        1   Kernel#nil? 
  0.00      0.000     0.000     0.000     0.000        1   <Class::IO>#open 
  0.00      0.000     0.000     0.000     0.000        2   Kernel#is_a? 
  0.00      0.000     0.000     0.000     0.000        1   Kernel#class 
  0.00      0.000     0.000     0.000     0.000        2   Array#include? 
```
