### PR TITLE
Skip the first row when reading if new header option is truthy

### DIFF
--- a/lib/fastest_csv.rb
+++ b/lib/fastest_csv.rb
@@ -180,12 +180,16 @@ class FastestCSV
     quote_char = @opts[:quote_char]
     grammar = @opts[:grammar]
 
+    shift(row_sep, check_field_count, col_sep, quote_char, grammar) if @opts[:header]
+    
     while row = shift(row_sep, check_field_count, col_sep, quote_char, grammar)
       yield row
     end
   end
 
   def each_raw_line
+    shift_raw_line if @opts[:header]
+
     while row = shift_raw_line
       yield row
     end

--- a/lib/fastest_csv.rb
+++ b/lib/fastest_csv.rb
@@ -180,7 +180,7 @@ class FastestCSV
     quote_char = @opts[:quote_char]
     grammar = @opts[:grammar]
 
-    shift(row_sep, check_field_count, col_sep, quote_char, grammar) if @opts[:header]
+    shift(row_sep, check_field_count, col_sep, quote_char, grammar) if @opts[:skip_header]
     
     while row = shift(row_sep, check_field_count, col_sep, quote_char, grammar)
       yield row
@@ -188,7 +188,7 @@ class FastestCSV
   end
 
   def each_raw_line
-    shift_raw_line if @opts[:header]
+    shift_raw_line if @opts[:skip_header]
 
     while row = shift_raw_line
       yield row

--- a/test/tc_csv_parsing.rb
+++ b/test/tc_csv_parsing.rb
@@ -204,19 +204,20 @@ class TestCSVParsing < Minitest::Test
   end
   
   def test_header_skipping
+    path = "test/test_data_relaxed.csv"
     rows_with_header = []
     rows_without_header = []
-    FastestCSV.foreach("test/test_data_relaxed.csv") { |row| rows_with_header << row }
-    FastestCSV.foreach("test/test_data_relaxed.csv", skip_header: true) { |row| rows_without_header << row }
-    assert(rows_with_header != rows_without_header, "output was the same with/without skip_header option")
-    assert_equal(1, rows_with_header.length - rows_without_header.length)
+    FastestCSV.foreach(path) { |row| rows_with_header << row }
+    FastestCSV.foreach(path, skip_header: true) { |row| rows_without_header << row }
+    refute_equal(rows_with_header, rows_without_header)
+    assert_equal(rows_with_header[1..-1], rows_without_header)
 
     rows_with_header = []
     rows_without_header = []
-    FastestCSV.foreach_raw_line("test/test_data_relaxed.csv") { |row| rows_with_header << row }
-    FastestCSV.foreach_raw_line("test/test_data_relaxed.csv", skip_header: true) { |row| rows_without_header << row }
-    assert(rows_with_header != rows_without_header, "output was the same with/without skip_header option")
-    assert_equal(1, rows_with_header.length - rows_without_header.length)
+    FastestCSV.foreach_raw_line(path) { |row| rows_with_header << row }
+    FastestCSV.foreach_raw_line(path, skip_header: true) { |row| rows_without_header << row }
+    refute_equal(rows_with_header, rows_without_header)
+    assert_equal(rows_with_header[1..-1], rows_without_header)
   end
 
 end

--- a/test/tc_csv_parsing.rb
+++ b/test/tc_csv_parsing.rb
@@ -202,5 +202,21 @@ class TestCSVParsing < Minitest::Test
                    FastestCSV.parse_line(csv_test.first, quote_char: '"'))
     end
   end
+  
+  def test_header_skipping
+    rows_with_header = []
+    rows_without_header = []
+    FastestCSV.foreach("test/test_data_relaxed.csv") { |row| rows_with_header << row }
+    FastestCSV.foreach("test/test_data_relaxed.csv", skip_header: true) { |row| rows_without_header << row }
+    assert(rows_with_header != rows_without_header, "output was the same with/without skip_header option")
+    assert_equal(1, rows_with_header.length - rows_without_header.length)
+
+    rows_with_header = []
+    rows_without_header = []
+    FastestCSV.foreach_raw_line("test/test_data_relaxed.csv") { |row| rows_with_header << row }
+    FastestCSV.foreach_raw_line("test/test_data_relaxed.csv", skip_header: true) { |row| rows_without_header << row }
+    assert(rows_with_header != rows_without_header, "output was the same with/without skip_header option")
+    assert_equal(1, rows_with_header.length - rows_without_header.length)
+  end
 
 end


### PR DESCRIPTION
I tried to do this with the least performance drain possible- it just grabs and discards the first line before yielding. Having an option like this would avoid needing to use boolean flagging in the app, which I've encountered the need for several times, and improve performance there since there wouldn't be a line number check on every iteration. @pospischil 
