### PR TITLE
Generation-related performance improvements

### DIFF
--- a/ext/csv_parser/parser.c
+++ b/ext/csv_parser/parser.c
@@ -305,7 +305,7 @@ static VALUE generate_line(VALUE self, VALUE array,
                 array_str_val_len = RSTRING_LEN(array_val);
             }
             else {
-                array_str_val = "";
+                array_str_val = (char *)"";
                 array_str_val_len = 0;
             }
 

--- a/lib/fastest-csv/version.rb
+++ b/lib/fastest-csv/version.rb
@@ -1,3 +1,3 @@
 class FastestCSV
-  VERSION = "0.7.7"
+  VERSION = "0.7.8"
 end

--- a/lib/fastest_csv.rb
+++ b/lib/fastest_csv.rb
@@ -163,7 +163,7 @@ class FastestCSV
     grammar = @opts[:grammar]
 
     shift(row_sep, check_field_count, col_sep, quote_char, grammar) if @opts[:skip_header]
-    
+
     while row = shift(row_sep, check_field_count, col_sep, quote_char, grammar)
       yield row
     end
@@ -195,8 +195,8 @@ class FastestCSV
       parsed_line, complete_line = CsvParser.parse_line(line, col_sep, quote_char, row_sep, grammar, 0)
       while !complete_line && (line = @io.gets(row_sep)) do
         parsed_partial_line, complete_line = CsvParser.parse_line(line, col_sep, quote_char, row_sep, grammar, 1)
-        parsed_line[parsed_line.length-1] += parsed_partial_line.shift
-        parsed_line += parsed_partial_line
+        parsed_line[parsed_line.length-1] << parsed_partial_line.shift
+        parsed_line.concat(parsed_partial_line)
       end
       if check_field_count && @field_count.nil?
         @field_count = parsed_line.length
@@ -236,7 +236,7 @@ class FastestCSV
     @current_buffer_count += 1
     line = CsvParser.generate_line(_array, col_sep, quote_char, row_sep, force_quotes) # should be UTF-8
     encoding_i = 0
-    while !line.valid_encoding?
+    until line.valid_encoding?
       # try encodings in sequence until one works, or raise exception if none work
       if encoding_i >= non_utf8_encodings.length
         raise RuntimeError, "Unable to encode following non-UTF-8 string to UTF-8 using any of #{non_utf8_encodings}:\n#{line}"
@@ -245,7 +245,7 @@ class FastestCSV
       encoding_i += 1
     end
     @current_write_buffer << line
-    if(@current_buffer_count == @opts[:write_buffer_lines])
+    if(@current_buffer_count == write_buffer_lines)
       flush(false)
     end
   end

--- a/lib/fastest_csv.rb
+++ b/lib/fastest_csv.rb
@@ -152,25 +152,16 @@ class FastestCSV
     _opts[:grammar] = (_opts[:grammar] == "strict") ? 0 : 1
 
     @opts = _opts
+    _opts.each do |k, v|
+      instance_variable_set(:"@#{k}", v)
+      self.class.send(:attr_reader, k) if !self.respond_to?(k)
+    end
 
     @io = io
     @current_buffer_count = 0
     @current_write_buffer = ""
     @field_count = @opts[:field_count]
-
   end
-
-  def col_sep; @col_sep ||= @opts[:col_sep]; end
-  def row_sep; @row_sep ||= @opts[:row_sep]; end
-  def quote_char; @quote_char ||= @opts[:quote_char]; end
-  def grammar; @grammar ||= @opts[:grammar]; end
-  def force_quotes; @force_quotes ||= @opts[:force_quotes]; end
-  def force_utf8; @force_utf8 ||= @opts[:force_utf8]; end
-  def write_buffer_lines; @write_buffer_lines ||= @opts[:write_buffer_lines]; end
-  def check_field_count; @check_field_count ||= @opts[:check_field_count]; end
-  def non_utf8_encodings; @non_utf8_encodings ||= @opts[:non_utf8_encodings]; end
-
-  def field_count; @field_count; end
 
   # Read from the wrapped IO passing each line as array to the specified block
   def each

--- a/lib/fastest_csv.rb
+++ b/lib/fastest_csv.rb
@@ -117,16 +117,7 @@ class FastestCSV
       force_quotes: false,
     }.merge(_opts)
     assert_valid_grammar(_opts[:col_sep], _opts[:quote_char], _opts[:row_sep], _opts[:grammar])
-    _opts[:grammar] = (_opts[:grammar] == "strict") ? 0 : 1
-    self.generate_line_no_check(data, _opts)
-  end
-
-  def self.generate_line_no_check(data, _opts)
-    CsvParser.generate_line(data.map{|x| x.nil? ? x : x.to_s},
-                            _opts[:col_sep],
-                            _opts[:quote_char],
-                            _opts[:row_sep],
-                            !!_opts[:force_quotes])
+    CsvParser.generate_line(data, _opts[:col_sep], _opts[:quote_char], _opts[:row_sep], !!_opts[:force_quotes])
   end
 
   # Create new FastestCSV wrapping the specified IO object
@@ -243,7 +234,7 @@ class FastestCSV
 
   def <<(_array)
     @current_buffer_count += 1
-    line = FastestCSV.generate_line_no_check(_array, @opts)  # should be UTF-8
+    line = CsvParser.generate_line(_array, col_sep, quote_char, row_sep, force_quotes) # should be UTF-8
     encoding_i = 0
     while !line.valid_encoding?
       # try encodings in sequence until one works, or raise exception if none work


### PR DESCRIPTION
A few changes that improve line-generation performance. I saw ~40% performance improvement.

Before:

```
Measure Mode: wall_time
Thread ID: 70150590423520
Fiber ID: 70150609666940
Total: 3.036751
Sort by: self_time

 %self      total      self      wait     child     calls  name
 13.60      0.721     0.413     0.000     0.308    99998   Array#map
 13.39      3.004     0.407     0.000     2.598        1   FastestCSV#each
  9.35      0.284     0.284     0.000     0.000   100000   <Module::CsvParser>#parse_line
  7.87      0.239     0.239     0.000     0.000    99998   <Module::CsvParser>#generate_line
  6.84      1.651     0.208     0.000     1.443    99998   FastestCSV#<<
  5.77      0.175     0.175     0.000     0.000   797807   Kernel#nil?
  5.63      0.171     0.171     0.000     0.000   999981   Array#[]
  5.04      0.556     0.153     0.000     0.403   100001   FastestCSV#shift
  4.83      1.259     0.147     0.000     1.113    99998   <Class::FastestCSV>#generate_line_no_check
  4.76      0.144     0.144     0.000     0.000   400003   BasicObject#!
  4.34      0.132     0.132     0.000     0.000   797805   String#to_s
  3.53      0.107     0.107     0.000     0.000   500009   Hash#[]
  2.84      0.086     0.086     0.000     0.000   300001   Fixnum#==
  2.64      0.080     0.080     0.000     0.000   100001   IO#gets
  1.94      0.116     0.059     0.000     0.057    99998   String#blank?
  1.88      0.057     0.057     0.000     0.000   199998   Fixnum#+
  1.17      0.035     0.035     0.000     0.000    99998   String#<<
  1.01      0.031     0.031     0.000     0.000    99998   String#valid_encoding?
  1.00      0.031     0.031     0.000     0.000   100002   String#length
  0.86      0.026     0.026     0.000     0.000    99998   String#end_with?
  0.63      0.019     0.019     0.000     0.000    99998   BasicObject#==
  0.38      0.012     0.012     0.000     0.000        1   IO#write
  0.23      0.007     0.007     0.000     0.000        3   IO#close
  0.08      0.013     0.002     0.000     0.011        5  *Kernel#require
  0.01      0.000     0.000     0.000     0.000     2179   NilClass#nil?
  0.01      0.000     0.000     0.000     0.000        1   String#lines
  0.01      0.000     0.000     0.000     0.000        3   File#initialize
...

* indicates recursively called methods
```

After:

```
Measure Mode: wall_time
Thread ID: 70150846276060
Fiber ID: 70150867324580
Total: 1.779921
Sort by: self_time

 %self      total      self      wait     child     calls  name
 20.33      1.760     0.362     0.000     1.399        1   FastestCSV#each 
 15.71      0.280     0.280     0.000     0.000   100000   <Module::CsvParser>#parse_line 
 13.33      0.237     0.237     0.000     0.000    99999   <Module::CsvParser>#generate_line 
 10.39      0.523     0.185     0.000     0.338    99999   FastestCSV#<< 
  9.92      0.177     0.177     0.000     0.000   999991   Array#[] 
  8.33      0.545     0.148     0.000     0.397   100001   FastestCSV#shift 
  4.38      0.078     0.078     0.000     0.000   100001   IO#gets 
  3.38      0.111     0.060     0.000     0.051    99999   String#blank? 
  2.62      0.047     0.047     0.000     0.000   200003   Fixnum#== 
  2.19      0.039     0.039     0.000     0.000   100029   BasicObject#! 
  1.81      0.032     0.032     0.000     0.000    99999   String#<< 
  1.60      0.028     0.028     0.000     0.000   100003   String#length 
  1.47      0.026     0.026     0.000     0.000    99999   String#valid_encoding? 
  1.39      0.025     0.025     0.000     0.000    99999   String#end_with? 
  1.04      0.019     0.019     0.000     0.000    99999   Fixnum#+ 
  1.03      0.018     0.018     0.000     0.000    99998   BasicObject#== 
  0.43      0.008     0.008     0.000     0.000        3   IO#close 
  0.34      0.006     0.006     0.000     0.000        1   IO#write 
  0.16      0.004     0.003     0.000     0.001        5  *Kernel#require 
  0.04      0.001     0.001     0.000     0.000        3   File#initialize 
  0.02      0.000     0.000     0.000     0.000        1   String#lines 
  0.01      1.780     0.000     0.000     1.780        2   Global#[No method] 
...

* indicates recursively called methods
```
