### PR TITLE
Fix rejection of non-string inputs

### DIFF
--- a/lib/fastest-csv/version.rb
+++ b/lib/fastest-csv/version.rb
@@ -1,3 +1,3 @@
 class FastestCSV
-  VERSION = "0.7.8"
+  VERSION = "0.7.9"
 end

--- a/test/tc_csv_generating.rb
+++ b/test/tc_csv_generating.rb
@@ -220,4 +220,13 @@ class TestCSVGenerating < Minitest::Test
 
   end
 
+  def test_non_string_cases
+    [
+      ["1,3.14,", [ 1, 3.14, nil ]],
+      ["2015-10-26,{},test", [ Date.new(2015, 10, 26), {}, "test"]]
+    ].each do |csv_test|
+      assert_equal(csv_test.first + "\n", FastestCSV.generate_line(csv_test.last))
+    end
+  end
+
 end


### PR DESCRIPTION
This fixes an issue with non-string inputs no longer being converted to strings. Instead of FastestCSV#generate_line doing it, it's now done in `CsvParser.generate_line`.

This also adds a test case covering some common non-string inputs since the regression was not caught by tests.
