### PR TITLE
C-escaped string support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.8
+- Added `c_escaped` grammar option to handle C-style escape sequences
+- Renamed the gem 'fastest_csv', in accordance with [Rubygems guidelines](http://guides.rubygems.org/name-your-gem/)
+- Cleaned up tests, imposed Rubocop
+
 # 0.7.6
 - Speed improvements to `parse_line`, removed `parse_line_no_check`
 

--- a/grammar.md
+++ b/grammar.md
@@ -68,3 +68,8 @@ The default option in this package is actually 'relaxed' grammar, which will att
   - if FIELDQUOTE is encountered in the middle of an escaped TEXTDATA but is not followed by another FIELDQUOTE, it will be interpreted as a regular character
 
 These departures from the fairly clean CSV grammar defined above are to help deal with common malformations in CSV that are still accepted by MySQL's `LOAD DATA INFILE`.
+
+
+## C-escaped
+
+There is a grammar option 'c_escaped' that will interpret all data in an escaped field above using a limited subset of C-like escape sequences. This was added because it is somewhat common for CSV files to use this style of escaping i.e. \" to represent a quotation mark, not "". If this grammar is used, FIELDQUOTE must be the double quote character, and the treatment of quotation marks will be strict - they must start and end a field.

--- a/lib/fastest_csv.rb
+++ b/lib/fastest_csv.rb
@@ -31,7 +31,7 @@ class FastestCSV
     if (fieldsep == fieldquote)
       fail "separator and quote characters cannot be the same"
     end
-    if !(["strict", "relaxed", "c_escaped"].include? grammar)
+    if !(['strict', 'relaxed', 'c_escaped'].include? grammar)
       fail "grammar must be 'strict', 'relaxed', or 'c_escaped'"
     end
     if grammar == "c_escaped" && fieldquote != DEFAULT_FIELDQUOTE
@@ -102,7 +102,7 @@ class FastestCSV
       col_sep:    DEFAULT_FIELDSEP,
       row_sep:    DEFAULT_LINEBREAK,
       quote_char: DEFAULT_FIELDQUOTE,
-      grammar:    "relaxed",
+      grammar:    'relaxed',
     }.merge(_opts)
     assert_valid_grammar(_opts[:col_sep], _opts[:quote_char], _opts[:row_sep], _opts[:grammar])
     _opts[:grammar] =
@@ -133,7 +133,7 @@ class FastestCSV
       col_sep:      DEFAULT_FIELDSEP,
       row_sep:      DEFAULT_LINEBREAK,
       quote_char:   DEFAULT_FIELDQUOTE,
-      grammar:      "relaxed",
+      grammar:      'relaxed',
       force_quotes: false,
     }.merge(_opts)
     assert_valid_grammar(_opts[:col_sep], _opts[:quote_char], _opts[:row_sep], _opts[:grammar])
@@ -155,7 +155,7 @@ class FastestCSV
       col_sep:      DEFAULT_FIELDSEP,
       row_sep:      DEFAULT_LINEBREAK,
       quote_char:   DEFAULT_FIELDQUOTE,
-      grammar:      "relaxed",
+      grammar:      'relaxed',
       force_quotes: false,
       force_utf8:   false,
       write_buffer_lines: DEFAULT_WRITE_BUFFER_LINES,

--- a/lib/fastest_csv.rb
+++ b/lib/fastest_csv.rb
@@ -18,21 +18,24 @@ class FastestCSV
     VERSION
   end
 
-  def self.assert_valid_grammar(_fieldsep, _fieldquote, _linebreak, _grammar)
-    if !((_fieldsep.is_a? String) && _fieldsep.length == 1)
+  def self.assert_valid_grammar(fieldsep, fieldquote, linebreak, grammar)
+    if !((fieldsep.is_a? String) && fieldsep.length == 1)
       fail "separator character must be a string of length 1"
     end
-    if !(_fieldquote.nil? || ((_fieldquote.is_a? String) && _fieldquote.length == 1))
+    if !(fieldquote.nil? || ((fieldquote.is_a? String) && fieldquote.length == 1))
       fail "quote character must be a string of length 1 (or nil, but only if we are parsing-only)"
     end
-    if !(["\r", "\n", "\r\n"].include? _linebreak)
+    if !(["\r", "\n", "\r\n"].include? linebreak)
       fail "linebreak must be CR, LF, or CR LF"
     end
-    if (_fieldsep == _fieldquote)
+    if (fieldsep == fieldquote)
       fail "separator and quote characters cannot be the same"
     end
-    if !(["strict", "relaxed"].include? _grammar)
-      fail "grammar must be 'strict' or 'relaxed'"
+    if !(["strict", "relaxed", "c_escaped"].include? grammar)
+      fail "grammar must be 'strict', 'relaxed', or 'c_escaped'"
+    end
+    if grammar == "c_escaped" && fieldquote != DEFAULT_FIELDQUOTE
+      fail "C-escaped grammar must use default field quote #{DEFAULT_FIELDQUOTE}"
     end
     true
   end
@@ -102,22 +105,45 @@ class FastestCSV
       grammar:    "relaxed",
     }.merge(_opts)
     assert_valid_grammar(_opts[:col_sep], _opts[:quote_char], _opts[:row_sep], _opts[:grammar])
-    _opts[:grammar] = (_opts[:grammar] == "strict") ? 0 : 1
-    output = CsvParser.parse_line(line, _opts[:col_sep], _opts[:quote_char], _opts[:row_sep], _opts[:grammar], 0)
+    _opts[:grammar] =
+      case _opts[:grammar]
+      when 'strict'
+        0
+      when 'relaxed'
+        1
+      when 'c_escaped'
+        2
+      else
+        fail "grammar must be 'strict', 'relaxed', or 'c_escaped'"
+      end
+    output = CsvParser.parse_line(
+      line,
+      _opts[:col_sep],
+      _opts[:quote_char],
+      _opts[:row_sep],
+      _opts[:grammar],
+      0,
+    )
     fail "Incomplete CSV line under strict grammar: #{line}" if _opts[:grammar] == 0 && !output[1]
     output[0]
   end
 
   def self.generate_line(data, _opts = {})
     _opts = {
-      col_sep:    DEFAULT_FIELDSEP,
-      row_sep:    DEFAULT_LINEBREAK,
-      quote_char: DEFAULT_FIELDQUOTE,
-      grammar:    "relaxed",
+      col_sep:      DEFAULT_FIELDSEP,
+      row_sep:      DEFAULT_LINEBREAK,
+      quote_char:   DEFAULT_FIELDQUOTE,
+      grammar:      "relaxed",
       force_quotes: false,
     }.merge(_opts)
     assert_valid_grammar(_opts[:col_sep], _opts[:quote_char], _opts[:row_sep], _opts[:grammar])
-    CsvParser.generate_line(data, _opts[:col_sep], _opts[:quote_char], _opts[:row_sep], _opts[:force_quotes])
+    CsvParser.generate_line(
+      data,
+      _opts[:col_sep],
+      _opts[:quote_char],
+      _opts[:row_sep],
+      _opts[:force_quotes],
+    )
   end
 
   # Create new FastestCSV wrapping the specified IO object
@@ -139,7 +165,17 @@ class FastestCSV
     }.merge(_opts)
 
     self.class.assert_valid_grammar(_opts[:col_sep], _opts[:quote_char], _opts[:row_sep], _opts[:grammar])
-    _opts[:grammar] = (_opts[:grammar] == "strict") ? 0 : 1
+    _opts[:grammar] =
+      case _opts[:grammar]
+      when 'strict'
+        0
+      when 'relaxed'
+        1
+      when 'c_escaped'
+        2
+      else
+        fail "grammar must be 'strict', 'relaxed', or 'c_escaped'"
+      end
 
     @opts = _opts
     _opts.each do |k, v|

--- a/lib/fastest_csv/version.rb
+++ b/lib/fastest_csv/version.rb
@@ -1,3 +1,3 @@
 class FastestCSV
-  VERSION = "0.7.9"
+  VERSION = "0.8"
 end

--- a/test/tc_csv_generating.rb
+++ b/test/tc_csv_generating.rb
@@ -99,9 +99,8 @@ class TestCSVGenerating < Minitest::Test
     end
   end
 
-  def test_aras_edge_cases
+  def test_edge_cases
     # with no force quote - mostly the same as parsing tests
-
     [ [%(a,b),               ["a", "b"]],
       [%(a,"""b"""),         ["a", "\"b\""]],
       [%(a,"""b"),           ["a", "\"b"]],
@@ -118,30 +117,8 @@ class TestCSVGenerating < Minitest::Test
       [%(,"\r"),             [nil, "\r"]],
       [%("\r\n,"),           ["\r\n,"]],
       [%("\r\n,",),          ["\r\n,", nil]],
-    ].each do |csv_test|
-      assert_equal(csv_test.first + "\n",
-                   FastestCSV.generate_line(csv_test.last))
-    end
-
-    # with force quote
-
-    [ [%("",""),             ["", ""]],
-      [%("""",""),           ["\"", ""]],
-      [%("",""),             [nil, ""]],
-    ].each do |csv_test|
-      assert_equal(csv_test.first + "\n",
-                   FastestCSV.generate_line(csv_test.last, force_quotes: true))
-    end
-  end
-
-  def test_james_edge_cases
-    assert_equal("\n", FastestCSV.generate_line([]))
-  end
-
-  def test_rob_edge_cases
-    # with no force quote - mostly the same as parsing tests
-
-    [ [%("a\nb"),                         ["a\nb"]],
+      ["",                   []],
+      [%("a\nb"),                         ["a\nb"]],
       [%("\n\n\n"),                       ["\n\n\n"]],
       [%(a,"b\n\nc"),                     ['a', "b\n\nc"]],
       [%(,"\r\n"),                        [nil, "\r\n"]],
@@ -151,27 +128,7 @@ class TestCSVGenerating < Minitest::Test
       [%("a\r\na",one CRLF),              ["a\r\na", 'one CRLF']],
       [%("a\r\n\r\na",two CRLFs),         ["a\r\n\r\na", 'two CRLFs']],
       [%(with blank,"start\n\nfinish",),  ['with blank', "start\n\nfinish", ""]],
-    ].each do |csv_test|
-      assert_equal(csv_test.first + "\n",
-                   FastestCSV.generate_line(csv_test.last))
-    end
-
-    # with force quote
-
-    [ [%("a\na","one newline"),           ["a\na", 'one newline']],
-      [%("a\n\na","two newlines"),        ["a\n\na", 'two newlines']],
-      [%("a\r\na","one CRLF"),            ["a\r\na", 'one CRLF']],
-      [%("a\r\n\r\na","two CRLFs"),       ["a\r\n\r\na", 'two CRLFs']],
-      [%("with blank","start\n\nfinish"), ['with blank', "start\n\nfinish"]],
-      [%("with blank","start\n\nfinish",""), ['with blank', "start\n\nfinish", ""]],
-    ].each do |csv_test|
-      assert_equal(csv_test.first + "\n",
-                   FastestCSV.generate_line(csv_test.last, force_quotes: true))
-    end
-  end
-
-  def test_jon_edge_cases
-    [ [%(wiggle,"waggle""this",another'thing),      ["wiggle", "waggle\"this", "another'thing"]],
+      [%(wiggle,"waggle""this",another'thing),      ["wiggle", "waggle\"this", "another'thing"]],
       [%(wiggle,"waggle""this",another''thing),     ["wiggle", "waggle\"this", "another''thing"]],
       [%(wiggle,"""waggle""this,another''thing"),   ["wiggle", "\"waggle\"this,another''thing"]],
       [%(wiggle,"""waggle""this,another''thing"""), ["wiggle", "\"waggle\"this,another''thing\""]],
@@ -180,7 +137,23 @@ class TestCSVGenerating < Minitest::Test
       [%(wiggle,"""waggle""this""""""","""""another''thing"""), ["wiggle", "\"waggle\"this\"\"\"", "\"\"another''thing\""]],
       [%(wiggle,"""""""waggle""""""""this"""""""""""""""),      ["wiggle", "\"\"\"waggle\"\"\"\"this\"\"\"\"\"\"\""]],
     ].each do |csv_test|
-      assert_equal(csv_test.first + "\n", FastestCSV.generate_line(csv_test.last))
+      assert_equal(csv_test.first + "\n",
+                   FastestCSV.generate_line(csv_test.last))
+    end
+
+    # with force quote
+    [ [%("",""),             ["", ""]],
+      [%("""",""),           ["\"", ""]],
+      [%("",""),             [nil, ""]],
+      [%("a\na","one newline"),           ["a\na", 'one newline']],
+      [%("a\n\na","two newlines"),        ["a\n\na", 'two newlines']],
+      [%("a\r\na","one CRLF"),            ["a\r\na", 'one CRLF']],
+      [%("a\r\n\r\na","two CRLFs"),       ["a\r\n\r\na", 'two CRLFs']],
+      [%("with blank","start\n\nfinish"), ['with blank', "start\n\nfinish"]],
+      [%("with blank","start\n\nfinish",""), ['with blank', "start\n\nfinish", ""]],
+    ].each do |csv_test|
+      assert_equal(csv_test.first + "\n",
+                   FastestCSV.generate_line(csv_test.last, force_quotes: true))
     end
   end
 
@@ -217,5 +190,4 @@ class TestCSVGenerating < Minitest::Test
       assert_equal(csv_test.first + "\n", FastestCSV.generate_line(csv_test.last))
     end
   end
-
 end

--- a/test/tc_csv_parsing.rb
+++ b/test/tc_csv_parsing.rb
@@ -105,9 +105,9 @@ class TestCSVParsing < Minitest::Test
     end
   end
 
-  # From:  http://ruby-talk.org/cgi-bin/scat.rb/ruby/ruby-core/6496
+  # From: http://ruby-talk.org/cgi-bin/scat.rb/ruby/ruby-core/6496 (URL now dead)
 
-  def test_aras_edge_cases
+  def test_edge_cases
     [ [%(a,b),               ["a", "b"]],
       [%(a,"""b"""),         ["a", "\"b\""]],
       [%(a,"""b"),           ["a", "\"b"]],
@@ -125,16 +125,7 @@ class TestCSVParsing < Minitest::Test
       [%(,"\r"),             [nil, "\r"]],
       [%("\r\n,"),           ["\r\n,"]],
       [%("\r\n,",),          ["\r\n,", nil]],
-    ].each do |csv_test|
-      assert_equal(csv_test.last,
-                   FastestCSV.parse_line(csv_test.first))
-      assert_equal(csv_test.last,
-                   FastestCSV.parse_line(csv_test.first, grammar: "strict"))
-    end
-  end
-
-  def test_rob_edge_cases
-    [ [%("a\nb"),                         ["a\nb"]],
+      [%("a\nb"),                         ["a\nb"]],
       [%("\n\n\n"),                       ["\n\n\n"]],
       [%(a,"b\n\nc"),                     ['a', "b\n\nc"]],
       [%(,"\r\n"),                        [nil, "\r\n"]],
@@ -144,16 +135,7 @@ class TestCSVParsing < Minitest::Test
       [%("a\r\na","one CRLF"),            ["a\r\na", 'one CRLF']],
       [%("a\r\n\r\na","two CRLFs"),       ["a\r\n\r\na", 'two CRLFs']],
       [%(with blank,"start\n\nfinish"\n), ['with blank', "start\n\nfinish"]],
-    ].each do |csv_test|
-      assert_equal(csv_test.last,
-                   FastestCSV.parse_line(csv_test.first))
-      assert_equal(csv_test.last,
-                   FastestCSV.parse_line(csv_test.first, grammar: "strict"))
-    end
-  end
-
-  def test_jon_edge_cases
-    [ [%(wiggle,"waggle""this",another'thing),      ["wiggle", "waggle\"this", "another'thing"]],
+      [%(wiggle,"waggle""this",another'thing),      ["wiggle", "waggle\"this", "another'thing"]],
       [%(wiggle,"waggle""this",another''thing),     ["wiggle", "waggle\"this", "another''thing"]],
       [%(wiggle,"""waggle""this,another''thing"),   ["wiggle", "\"waggle\"this,another''thing"]],
       [%(wiggle,"""waggle""this,another''thing"""), ["wiggle", "\"waggle\"this,another''thing\""]],

--- a/test/tc_speed.rb
+++ b/test/tc_speed.rb
@@ -76,33 +76,4 @@ class TestCSVSpeed < Minitest::Test
     assert(fastest_csv_time < csv_time / 3)
   end
 
-  # BIG_DATA = "123456789\n" * 1024
-
-  # We don't have bad CSV error checking in this gem as it currently stands, so
-  # this part is commented out
-
-  # def test_the_parse_fails_fast_when_it_can_for_unquoted_fields
-  #   assert_parse_errors_out('valid,fields,bad start"' + BIG_DATA)
-  # end
-
-  # def test_the_parse_fails_fast_when_it_can_for_unescaped_quotes
-  #   assert_parse_errors_out('valid,fields,"bad start"unescaped' + BIG_DATA)
-  # end
-
-  # def test_field_size_limit_controls_lookahead
-  #   assert_parse_errors_out( 'valid,fields,"' + BIG_DATA + '"',
-  #                            :field_size_limit => 2048 )
-  # end
-
-  # private
-
-  # def assert_parse_errors_out(*args)
-  #   assert_raise(FasterCSV::MalformedCSVError) do
-  #     Timeout.timeout(0.2) do
-  #       FasterCSV.parse(*args)
-  #       fail("Parse didn't error out")
-  #     end
-  #   end
-  # end
-
 end


### PR DESCRIPTION
- We now support grammar that assumes strings have C-style escaping
- Gem name is now `fastest_csv`
- This PR bumps version to 0.8
