### PR TITLE
Add option to specify escape char

### DIFF
--- a/ext/csv_parser/parser.c
+++ b/ext/csv_parser/parser.c
@@ -330,7 +330,7 @@ static VALUE parse_line(VALUE self, VALUE str,
 
 static VALUE generate_line(VALUE self, VALUE array,
                            VALUE sep_char, VALUE quote_char, VALUE linebreak_char,
-                           VALUE force_quotes) {
+                           VALUE force_quotes, VALUE escape_char) {
 
     char c;
     char *array_str_val, *converted_val;
@@ -341,6 +341,7 @@ static VALUE generate_line(VALUE self, VALUE array,
 
     const char *sepc;
     const char *quotec;
+    const char *escapec;
     const char *linebreakc;
 
     int crlf;
@@ -356,6 +357,10 @@ static VALUE generate_line(VALUE self, VALUE array,
     if (NIL_P(quote_char))
         rb_raise(rb_eArgError, "quote_char may not be nil");
     quotec = RSTRING_PTR(quote_char);
+
+    if (NIL_P(escape_char))
+        rb_raise(rb_eArgError, "escape_char may not be nil");
+    escapec = RSTRING_PTR(escape_char);
 
     linebreakc = RSTRING_PTR(linebreak_char);
     crlf = strcmp(linebreakc, "\r\n") == 0 ? 1 : 0;
@@ -409,9 +414,9 @@ static VALUE generate_line(VALUE self, VALUE array,
             if (!quoting && (c == quotec[0] || c == sepc[0] || c == 13 || c == 10)) {
                 quoting = 1;
             }
-            /* if quote_char, dupe it */
+            /* if quote_char, escape it */
             if (c == quotec[0]) {
-                converted_val[converted_i] = c;
+                converted_val[converted_i] = escapec[0];
                 converted_val[converted_i+1] = c;
                 converted_i += 2;
             }
@@ -462,5 +467,5 @@ void Init_csv_parser()
 {
     mCsvParser = rb_define_module("CsvParser");
     rb_define_module_function(mCsvParser, "parse_line", parse_line, 6);
-    rb_define_module_function(mCsvParser, "generate_line", generate_line, 5);
+    rb_define_module_function(mCsvParser, "generate_line", generate_line, 6);
 }

--- a/lib/fastest_csv.rb
+++ b/lib/fastest_csv.rb
@@ -140,6 +140,9 @@ class FastestCSV
       grammar:      'relaxed',
       force_quotes: false,
     }.merge(_opts)
+
+    _opts[:escape_char] = _opts[:quote_char] if _opts[:escape_char].nil?
+
     assert_valid_grammar(_opts[:col_sep], _opts[:quote_char], _opts[:row_sep], _opts[:grammar])
     CsvParser.generate_line(
       data,
@@ -147,6 +150,7 @@ class FastestCSV
       _opts[:quote_char],
       _opts[:row_sep],
       _opts[:force_quotes],
+      _opts[:escape_char],
     )
   end
 
@@ -159,6 +163,7 @@ class FastestCSV
       col_sep:      DEFAULT_FIELDSEP,
       row_sep:      DEFAULT_LINEBREAK,
       quote_char:   DEFAULT_FIELDQUOTE,
+      escape_char:  nil,
       grammar:      'relaxed',
       force_quotes: false,
       force_utf8:   false,
@@ -167,6 +172,8 @@ class FastestCSV
       field_count:        nil,
       non_utf8_encodings: ["ISO-8859-1"],
     }.merge(_opts)
+
+    _opts[:escape_char] = _opts[:quote_char] if _opts[:escape_char].nil?
 
     self.class.assert_valid_grammar(_opts[:col_sep], _opts[:quote_char], _opts[:row_sep], _opts[:grammar])
     _opts[:grammar] =
@@ -276,7 +283,7 @@ class FastestCSV
 
   def <<(_array)
     @current_buffer_count += 1
-    line = CsvParser.generate_line(_array, col_sep, quote_char, row_sep, force_quotes) # should be UTF-8
+    line = CsvParser.generate_line(_array, col_sep, quote_char, row_sep, force_quotes, escape_char) # should be UTF-8
     encoding_i = 0
     until line.valid_encoding?
       # try encodings in sequence until one works, or raise exception if none work

--- a/test/tc_csv_generating.rb
+++ b/test/tc_csv_generating.rb
@@ -20,6 +20,10 @@ class TestCSVGenerating < Minitest::Test
       %(Ten Thousand,10000, 2710 ,,'10,000','It''s "10 Grand", baby',10K\n),
       [ "Ten Thousand", "10000", " 2710 ", nil, "10,000", "It's \"10 Grand\", baby", "10K" ],
     ]
+    case_escape = [
+      %(Ten Thousand,10000, 2710 ,,"10,000","It's \\"10 Grand\\", baby",10K\n),
+      [ "Ten Thousand", "10000", " 2710 ", nil, "10,000", "It's \"10 Grand\", baby", "10K" ],
+    ]
     case_linebreak1 = [
       %(Ten Thousand,10000, 2710 ,,"10,000","It's ""10 Grand"", baby",10K\r\n),
       [ "Ten Thousand", "10000", " 2710 ", nil, "10,000", "It's \"10 Grand\", baby", "10K" ],
@@ -35,6 +39,8 @@ class TestCSVGenerating < Minitest::Test
                  FastestCSV.generate_line(case_sep.last, col_sep: ";"))
     assert_equal(case_quote.first,
                  FastestCSV.generate_line(case_quote.last, quote_char: "'"))
+    assert_equal(case_escape.first,
+                 FastestCSV.generate_line(case_escape.last, escape_char: "\\"))
     assert_equal(case_linebreak1.first,
                  FastestCSV.generate_line(case_linebreak1.last, row_sep: "\r\n"))
     assert_equal(case_linebreak2.first,


### PR DESCRIPTION
Spark CSV doesn't handle two double quotes ("") properly, despite the fact that "" is the RFC standard. We're currently losing some lines with FastestCSV using "" as the escape, switching the double quote char to backslash makes SparkCSV (as of 2.3.1) read more lines.